### PR TITLE
Hotfix fetch score endpoint call

### DIFF
--- a/html-redirect-js/src/finished.js
+++ b/html-redirect-js/src/finished.js
@@ -5,11 +5,12 @@ async function app() {
   app.innerHTML = `<h1>Loading...</h1>`;
   
   const interviewId = localStorage.getItem('interviewId');
-  if (!interviewId) {
+   if (!interviewId) {
     app.innerHTML = `<h1>Error: Invalid interviewId</h1>`;
   }
+  const token = localStorage.getItem('token');
 
-  const score = await fetchScore(interviewId);
+  const score = await fetchScore(interviewId, token);
   
   if(score.success){
     app.innerHTML =`<h1>Onboarding finished with score: ${score.score}</h1>`;

--- a/html-redirect-js/src/main.js
+++ b/html-redirect-js/src/main.js
@@ -7,10 +7,11 @@ async function app() {
   startButton.addEventListener('click', async ()=>{
     app.innerHTML = `<h1>Loading...</h1>`;
     try {
-      const {success, error, url, interviewId} = await fetchOnboardingUrl();
+      const {success, error, url, interviewId, token} = await fetchOnboardingUrl();
       if (success){
         localStorage.setItem("interviewId", interviewId);
-        
+        localStorage.setItem("token", token);
+
         app.innerHTML =`<h1><a href="${url}">Click Here to Continue</a></h1>`;
         window.location.replace(url);
       } else {

--- a/html-redirect-js/src/onboarding.js
+++ b/html-redirect-js/src/onboarding.js
@@ -1,7 +1,10 @@
 const tokenServerURL=import.meta.env.VITE_TOKEN_SERVER_URL;
 
-export async function fetchScore(interviewId) {
-    const response = await fetch(`${tokenServerURL}/fetch-score=?interviewId=${interviewId}`, {});
+export async function fetchScore(interviewId, token) {  
+    const headers = new Headers({
+      'X-Incode-Hardware-Id': token
+    });
+    const response = await fetch(`${tokenServerURL}/fetch-score?interviewId=${interviewId}`, {headers});
     return await response.json();
   }
 


### PR DESCRIPTION
The /fetch-score endpoint requires the session token to work, although it was not being passing to the endpoint. In summary:

- Added the session token to the localStorage right after the /onboarding-url call;
- Then, retrieve it from the localStorage in the /finished screen and send it as a header to the /fetch-score endpoint.